### PR TITLE
Dockerfile source image updates to opendjk

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,7 +1,7 @@
 #
 # conductor:server - Netflix conductor server
 #
-FROM java:8-jre-alpine
+FROM openjdk:8-jre-alpine
 
 MAINTAINER Netflix OSS <conductor@netflix.com>
 

--- a/docker/serverAndUI/Dockerfile
+++ b/docker/serverAndUI/Dockerfile
@@ -1,7 +1,7 @@
 #
 # conductor:serverAndUI - Netflix conductor server and UI
 #
-FROM java:8-jdk
+FROM openjdk:8-jdk
 
 MAINTAINER Netflix OSS <conductor@netflix.com>
 


### PR DESCRIPTION
Updating docker files for Conductor Server to use OpenJDK. Since the "java" images are deprecated and a few years old, this also means the version of these images it pulls will be significantly newer - particularly the version of alpine that is pulled.

Specifically this update is to address issues with the overlay file system present in the java JDK / alpine distribution that is being used. This causes file system errors with Elasticache on Windows systems running docker.